### PR TITLE
use seconds as baseunit for duration metrics

### DIFF
--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -89,8 +89,8 @@ const gaugeNumSlicers = new Gauge({
 });
 
 const gaugeQueryDuration = new Gauge({
-    name: `${metricPrefix}_query_duration`,
-    help: 'Total time to complete the named query, in ms.',
+    name: `${metricPrefix}_query_duration_seconds`,
+    help: 'Total time to complete the named query, in seconds.',
     labelNames: ['query_name', ...globalLabelNames],
     registers: [metricsRegistry],
 });

--- a/src/teraslice-stats.ts
+++ b/src/teraslice-stats.ts
@@ -84,7 +84,7 @@ export default class TerasliceStats implements TerasliceStatsInterface {
 
         const NS_PER_SEC = 1e9;
         const diff = process.hrtime(time);
-        this.queryDuration.executions = Math.round((diff[0] * NS_PER_SEC + diff[1]) / 1e6);
+        this.queryDuration.executions = (diff[0] * NS_PER_SEC + diff[1]) / 1e9;
     }
 
     // I think I've been doing this sort of thing wrong in the past.
@@ -105,10 +105,10 @@ export default class TerasliceStats implements TerasliceStatsInterface {
             this.state = state.data;
             await this.updateExecutions();
 
-            this.queryDuration.info = info.queryDuration;
-            this.queryDuration.jobs = jobs.queryDuration;
-            this.queryDuration.controllers = controllers.queryDuration;
-            this.queryDuration.state = state.queryDuration;
+            this.queryDuration.info = info.queryDuration / 1e3;
+            this.queryDuration.jobs = jobs.queryDuration / 1e3;
+            this.queryDuration.controllers = controllers.queryDuration / 1e3;
+            this.queryDuration.state = state.queryDuration / 1e3;
         };
         await run();
     }


### PR DESCRIPTION
Trying to follow some suggested conventions:
https://prometheus.io/docs/practices/naming/

Will produce output like:

```
# HELP teraslice_query_duration_seconds Total time to complete the named query, in seconds.
# TYPE teraslice_query_duration_seconds gauge
teraslice_query_duration_seconds{query_name="info",url="https://ts-xxx/",name="teraslice-xxx"} 0.182
teraslice_query_duration_seconds{query_name="jobs",url="https://ts-xxx/",name="teraslice-xxx"} 0.251
teraslice_query_duration_seconds{query_name="controllers",url="https://ts-xxx/",name="teraslice-xxx"} 0.185
teraslice_query_duration_seconds{query_name="executions",url="https://ts-xxx/",name="teraslice-xxx"} 0.202503852
teraslice_query_duration_seconds{query_name="state",url="https://ts-xxx/",name="teraslice-xxx"} 0.18
```

the `executions` metric seems to have a bit more precision, but not sure if it's worth rounding for aesthetics.

closes #5 