### PR TITLE
optional TERASLICE_DISPLAY_URL env parameter for metric url labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ So far it works like this:
 
 ```bash
 TERASLICE_URL="https://localhost" \
+TERASLICE_DISPLAY_URL="https://teraslice-xyz.lan" \
   DEBUG=True \
   NODE_EXTRA_CA_CERTS=/path/to/ca.crt \
   node dist/index.js | bunyan
@@ -19,6 +20,7 @@ All options are passed as environment variables
 
 ```bash
 TERASLICE_URL="https://localhost" \
+TERASLICE_DISPLAY_URL="https://teraslice-xyz.lan" \
   DEBUG=True \
   NODE_EXTRA_CA_CERTS=/path/to/ca.crt \
   PORT=4242 \
@@ -31,6 +33,7 @@ The `TERASLICE_URL` is the only environment variable that is required.
 ### Environment variables
 
 * `TERASLICE_URL` - URL to the Teraslice Instance to Monitor
+* `TERASLICE_DISPLAY_URL` - Optional override of TERASLICE_URL for metric label purposes only
 * `DEBUG` - Enable debug logging
 * `NODE_EXTRA_CA_CERTS` - Standard Node variable to specify CA cert for SSL
 connections

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ So far it works like this:
 
 ```bash
 TERASLICE_URL="https://localhost" \
-TERASLICE_DISPLAY_URL="https://teraslice-xyz.lan" \
+  TERASLICE_DISPLAY_URL="https://teraslice-xyz.lan" \
   DEBUG=True \
   NODE_EXTRA_CA_CERTS=/path/to/ca.crt \
   node dist/index.js | bunyan
@@ -20,7 +20,7 @@ All options are passed as environment variables
 
 ```bash
 TERASLICE_URL="https://localhost" \
-TERASLICE_DISPLAY_URL="https://teraslice-xyz.lan" \
+  TERASLICE_DISPLAY_URL="https://teraslice-xyz.lan" \
   DEBUG=True \
   NODE_EXTRA_CA_CERTS=/path/to/ca.crt \
   PORT=4242 \

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "author": "Terascope, LLC <info@terascope.io>",
-    "version": "0.1.1",
+    "version": "0.2.0",
     "license": "MIT",
     "dependencies": {
         "bunyan": "^1.8.14",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ declare let process : {
         DEBUG: string,
         PORT: number,
         TERASLICE_URL: string
+        TERASLICE_DISPLAY_URL: string
         TERASLICE_QUERY_DELAY: number
     }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ declare let process : {
 
 async function main() {
     let baseUrl: string;
+    let displayUrl: string;
 
     const server = express();
     const port = process.env.PORT || 3000;
@@ -29,6 +30,13 @@ async function main() {
         baseUrl = new URL(process.env.TERASLICE_URL).toString();
     } else {
         throw new Error('The TERASLICE_URL environment variable must be a valid URL to the root of your teraslice instance.');
+    }
+    if (process.env.TERASLICE_DISPLAY_URL) {
+    // I instantiate a URL, then immediately call toString() just to get the
+    // URL validation but keep a string type
+        displayUrl = new URL(process.env.TERASLICE_DISPLAY_URL).toString();
+    } else {
+        displayUrl = baseUrl;
     }
     const terasliceQueryDelay = process.env.TERASLICE_QUERY_DELAY || 30000; // ms
     const logger = bunyan.createLogger({
@@ -49,7 +57,7 @@ async function main() {
     // node v14+
     if (process?.env?.DEBUG?.toLowerCase() === 'true') logger.level('debug');
 
-    const terasliceStats = new TerasliceStats(baseUrl);
+    const terasliceStats = new TerasliceStats(baseUrl, displayUrl);
     await terasliceStats.update();
     updateTerasliceMetrics(terasliceStats);
 

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -435,14 +435,8 @@ function generateExecutionVersions(terasliceStats:TerasliceStats, labels:any) {
 export function updateTerasliceMetrics(terasliceStats: TerasliceStats): void {
     metricsRegistry.resetMetrics();
 
-    let baseURLLabel = terasliceStats.baseUrl.toString()
-
-    if (process?.env?.TERASLICE_DISPLAY_URL) {
-        baseURLLabel = process?.env?.TERASLICE_DISPLAY_URL?.toLowerCase()
-    }
-
     const globalLabels = {
-        url: baseURLLabel,
+        url: terasliceStats.displayUrl.toString(),
         name: terasliceStats.info.name,
     };
     // NOTE: This set of labels expands out to including 'name' twice, right now

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -435,8 +435,14 @@ function generateExecutionVersions(terasliceStats:TerasliceStats, labels:any) {
 export function updateTerasliceMetrics(terasliceStats: TerasliceStats): void {
     metricsRegistry.resetMetrics();
 
+    let baseURLLabel = terasliceStats.baseUrl.toString()
+
+    if (process?.env?.TERASLICE_DISPLAY_URL) {
+        baseURLLabel = process?.env?.TERASLICE_DISPLAY_URL?.toLowerCase()
+    }
+
     const globalLabels = {
-        url: terasliceStats.baseUrl.toString(),
+        url: baseURLLabel,
         name: terasliceStats.info.name,
     };
     // NOTE: This set of labels expands out to including 'name' twice, right now

--- a/src/teraslice-stats.ts
+++ b/src/teraslice-stats.ts
@@ -10,6 +10,8 @@ import { pDelay } from './util';
 export default class TerasliceStats implements TerasliceStatsInterface {
     baseUrl: URL;
 
+    displayUrl: string;
+
     controllers: any[];
 
     executions: any[];
@@ -22,8 +24,9 @@ export default class TerasliceStats implements TerasliceStatsInterface {
 
     queryDuration: TerasliceQueryDuration;
 
-    constructor(baseUrl:string) {
+    constructor(baseUrl:string, displayUrl:string) {
         this.baseUrl = new URL(baseUrl);
+        this.displayUrl = displayUrl;
         this.controllers = [];
         this.executions = [];
         this.jobs = [];


### PR DESCRIPTION
If not provided, `url` metric label defaults to `TERASLICE_URL`

Provide an optional display name for url:
```
TERASLICE_URL="https://ts-xxx.lan" \
TERASLICE_DISPLAY_URL="https://teraslice.lan" \
  DEBUG=True \
  NODE_EXTRA_CA_CERTS=/path/to/ca.crt \
  node dist/index.js | bunyan
````

```
# HELP teraslice_query_duration Total time to complete the named query, in ms.
# TYPE teraslice_query_duration gauge
teraslice_query_duration{query_name="info",url="https://teraslice.lan",name="teraslice-xxx"} 255
teraslice_query_duration{query_name="jobs",url="https://teraslice.lan",name="teraslice-xxx"} 518
teraslice_query_duration{query_name="controllers",url="https://teraslice.lan",name="teraslice-xxx"} 257
teraslice_query_duration{query_name="executions",url="https://teraslice.lan",name="teraslice-xxx"} 196
teraslice_query_duration{query_name="state",url="https://teraslice.lan",name="teraslice-xxx"} 252
```


If you omit `TERASLICE_DISPLAY_URL` or set it to "",  `url` defaults to `TERASLICE_URL`:

```
TERASLICE_URL="https://ts-xxx.lan" \
  DEBUG=True \
  NODE_EXTRA_CA_CERTS=/path/to/ca.crt \
  node dist/index.js | bunyan
````

```
# HELP teraslice_query_duration Total time to complete the named query, in ms.
# TYPE teraslice_query_duration gauge
teraslice_query_duration{query_name="info",url="https://ts-xxx.lan/",name="teraslice-xxx"} 193
teraslice_query_duration{query_name="jobs",url="https://ts-xxx.lan/",name="teraslice-xxx"} 235
teraslice_query_duration{query_name="controllers",url="https://ts-xxx.tera1.lan/",name="teraslice-xxx"} 201
teraslice_query_duration{query_name="executions",url="https://ts-xxx.lan/",name="teraslice-xxx"} 196
teraslice_query_duration{query_name="state",url="https://ts-xxx.lan/",name="teraslice-xxx"} 463
```

closes https://github.com/terascope/teraslice-exporter/issues/4
