### PR TITLE
Update base docker image to node:18-bookworm-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:14-buster-slim as build
+FROM node:18-bookworm-slim as build
 WORKDIR /app/source
 COPY package.json .
 RUN npm install && npm install typescript
 ADD . /app/source
 RUN npx tsc
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 WORKDIR /app/source
 COPY --from=build /app/source /app/source
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ value is in ms.
 Build the docker image:
 
 ```bash
-docker build -t teraslice-exporter:v0.1.0 .
+docker build -t teraslice-exporter:v0.4.0 .
 ```
 
 Run the docker image:
@@ -54,7 +54,7 @@ Run the docker image:
 ```bash
 docker run --rm -p 3000:3000 \
     -e TERASLICE_URL="http://url.to.teraslice/" \
-    teraslice-exporter:v0.1.0 | bunyan
+    teraslice-exporter:v0.4.0 | bunyan
 ```
 
 ## Design

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "author": "Terascope, LLC <info@terascope.io>",
-    "version": "0.3.1",
+    "version": "0.4.0",
     "license": "MIT",
     "dependencies": {
         "bunyan": "^1.8.14",


### PR DESCRIPTION
This PR includes the following changes:
- Update base docker image from `node:14-buster-slim` to `node:18-bookworm-slim`
- Bump version from `0.3.1` to `0.4.0`
- Update `README.md` to use the latest version image tag